### PR TITLE
Enable dynamic tab completion for Pivot parameters

### DIFF
--- a/Network-Performance-Visualization.psd1
+++ b/Network-Performance-Visualization.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Network-Performance-Visualization.psm1'
 
 # Version number of this module.
-ModuleVersion = '2020.09.24.0'
+ModuleVersion = '2020.09.25.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Now you don't need to guess what the valid pivot values are. E.g. typing `-NTTTCP -InnerPivot <tab>` will cycle through `sessions`, `bufferLen`, `bufferCount`, and `none`. Also, typing `-NTTTCP -InnerPivot bu<tab>` will cycle through just `bufferLen` and `bufferCount`.